### PR TITLE
Added input filtering when pasting HTML

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -171,7 +171,7 @@ export default Ember.Component.extend({
     }
 
     if (type !== 'html' && value.indexOf('<') !== -1) {
-        value = Ember.$(Ember.$.parseHTML(string)).text();
+        value = Ember.$(Ember.$.parseHTML(value)).text();
     }
 
     if (type === 'number') {

--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -136,7 +136,9 @@ export default Ember.Component.extend({
   /* Events */
   handlePaste(event, _this) {
     let content = event.originalEvent.clipboardData.getData('text');
-    const currentVal = _this._getInputValue();
+    const currentVal = _this._getInputValue();    
+    const type = this.get('type');
+
 
     if (!Ember.isEmpty(_this.get('maxlength'))) {
       event.preventDefault();
@@ -161,13 +163,18 @@ export default Ember.Component.extend({
     }
 
     var value = this.get('value');
+    
     this.set('_observeValue', false);
 
     if (!this.get('allowNewlines')) {
       value = value.toString().replace(/\n/g, ' ');
     }
 
-    if (this.get('type') === 'number') {
+    if (type !== 'html' && value.indexOf('<') !== -1) {
+        value = Ember.$(Ember.$.parseHTML(string)).text();
+    }
+
+    if (type === 'number') {
       value = value.toString().replace(/[^0-9]/g, '');
     }
 

--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -139,6 +139,9 @@ export default Ember.Component.extend({
     const currentVal = _this._getInputValue();    
     const type = this.get('type');
 
+    if (type !== 'html' && value.indexOf('<') !== -1) {
+        content = Ember.$(Ember.$.parseHTML(content)).text();
+    }
 
     if (!Ember.isEmpty(_this.get('maxlength'))) {
       event.preventDefault();
@@ -168,10 +171,6 @@ export default Ember.Component.extend({
 
     if (!this.get('allowNewlines')) {
       value = value.toString().replace(/\n/g, ' ');
-    }
-
-    if (type !== 'html' && value.indexOf('<') !== -1) {
-        value = Ember.$(Ember.$.parseHTML(value)).text();
     }
 
     if (type === 'number') {


### PR DESCRIPTION
When the type is not HTML any pasted input is cleaned from HTML tags.
Without this fix, formatting bugs appear when pasting from text editors and spreadsheets with formatted contents.
