### PR TITLE
Handle HTML contet as HTML content and not as plain text

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -77,7 +77,12 @@ export default Ember.Component.extend({
 
   setValue() {
     if (this.element) {
-      this.$().text(this.get('value'));
+      if (this.type === 'html') {
+        this.$().html(this.get('value'));
+      }
+      else {
+        this.$().text(this.get('value'));  
+      }
     }
   },
 


### PR DESCRIPTION
If you use this with the idea to store HTML content in the DB, this fix enables it to display proper HTML content in the ember-content-editable component when it loads from the DB for the first time.