### PR TITLE
Handle pasting of blank lines

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -136,8 +136,15 @@ export default Ember.Component.extend({
   /* Events */
   handlePaste(event, _this) {
     let content = event.originalEvent.clipboardData.getData('text');
+    
+    if (!Ember.isNone(content) && Ember.isEmpty(content.trim())){
+      // Pasting empty strings into a contentEditable causes issues as it is truncated.
+      // Skip handling in this case.
+      return
+    }
+    
     const currentVal = _this._getInputValue();
-
+   
     if (!Ember.isEmpty(_this.get('maxlength'))) {
       event.preventDefault();
 

--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -140,7 +140,7 @@ export default Ember.Component.extend({
     if (!Ember.isNone(content) && Ember.isEmpty(content.trim())){
       // Pasting empty strings into a contentEditable causes issues as it is truncated.
       // Skip handling in this case.
-      return
+      return;
     }
     
     const currentVal = _this._getInputValue();


### PR DESCRIPTION
Thank you for this awesome library!

We ran into an issue today. If a user pastes a blank space into the input (why they would want to is beyond me...), an error is thrown on this line `range.setStart(_this.element.childNodes[0], start + content.length);`, due to `_this.element.childNodes` being an empty array.

I'm guessing it's because whitespace is insignificant and so is truncated away, or something, but this MR just skips processing of pastes that consist of nothing but whitespace.