### PR TITLE
Paste event now pastes at and retains cursor location

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -185,7 +185,10 @@ export default Component.extend({
       let end = window.getSelection().getRangeAt(0).endOffset;
 
       let freeSpace = _this.get('maxlength') - currentVal.length + (end - start);
-      content = content.substring(0, freeSpace);
+      if (_this.get('maxlength')) {
+        //Truncate content if there is a maxlength and content is larger than it
+        content = content.substring(0, freeSpace);
+      }
 
       this.insertTextAtCursor(content);
     }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    // Add options here
+    babel: {
+      includePolyfill: true
+    }
   });
 
   /*

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,9 +5,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    babel: {
-      includePolyfill: true
-    }
+
   });
 
   /*

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -3,12 +3,17 @@ import moduleForAcceptance from '../helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | login');
 
-test('visiting /', async function(assert) {
-  await visit('/');
-  assert.equal(currentURL(), '/');
+test('visiting /', function(assert) {
+  visit('/');
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+  });
 
-  await fillContentEditable('.jsTest-textInput', 'Hi there!');
-  assert.equal(find('input').val(), 'Hi there!', 'content editable text bound to input');
-  assert.equal(find('.jsTest-textOutput').text().trim(), 'Hi there!', 'content editable html bound to p');
+  fillContentEditable('.jsTest-textInput', 'Hi there!');
+
+  andThen(function() {
+    assert.equal(find('input').val(), 'Hi there!', 'content editable text bound to input');
+    assert.equal(find('.jsTest-textOutput').text().trim(), 'Hi there!', 'content editable html bound to p');
+  });
 
 });

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -3,17 +3,12 @@ import moduleForAcceptance from '../helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | login');
 
-test('visiting /', function(assert) {
-  visit('/');
+test('visiting /', async function(assert) {
+  await visit('/');
+  assert.equal(currentURL(), '/');
 
-  andThen(function() {
-    assert.equal(currentURL(), '/');
-  });
+  await fillContentEditable('.jsTest-textInput', 'Hi there!');
+  assert.equal(find('input').val(), 'Hi there!', 'content editable text bound to input');
+  assert.equal(find('.jsTest-textOutput').text().trim(), 'Hi there!', 'content editable html bound to p');
 
-  fillContentEditable('div.ember-content-editable', 'Hi there!');
-
-  andThen(function() {
-    assert.equal(find('input').val(), 'Hi there!', 'content editable html bound to input');
-    assert.equal(find('p').text().trim(), 'Hi there!', 'content editable html bound to p');
-  });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   name: "<b>yo<i>lo</i></b> yup",
+  htmlText: '<div>In a div</div>',
 
   filter(currentValue, event) {
     var k = event.which;

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,4 @@
+
+.u-whiteSpacePre {
+  white-space: pre;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,9 +1,17 @@
-<h1>Content Editable Component</h1>
+<h1>Content Editable Component - Text</h1>
 
-{{content-editable value=name placeholder="Name" type="text" maxlength=2000}}
+{{content-editable value=name placeholder="Name" type="text" maxlength=2000 class="u-whiteSpacePre jsTest-textInput"}}
 
 <h1>Input</h1>
 {{input value=name spellcheck=true}}
 
-<h1>Label</h1>
-<p>{{name}}</p>
+<h1>Text output</h1>
+<p class="u-whiteSpacePre jsTest-textOutput">{{name}}</p>
+
+
+<h1>Content Editable Component - HTML</h1>
+
+{{content-editable value=htmlText placeholder="HTML text" type="html" }}
+
+<h1>HTML output</h1>
+<p>{{{htmlText}}}</p>

--- a/tests/integration/components/content-editable-test.js
+++ b/tests/integration/components/content-editable-test.js
@@ -307,3 +307,30 @@ test('allowNewlines=false works', function(assert) {
   $element.trigger($.Event("keydown", { keyCode: 13})); // Enter
   $element.trigger($.Event("keydown", { keyCode: 65 })); // Not enter
 });
+
+test('Pasting works', async function(assert) {
+  assert.expect(1);
+  this.set('value', "");
+
+  //Make mock event
+  let event = document.createEvent("CustomEvent");
+  event.initCustomEvent('paste', true, true, null);
+  event.originalEvent = {
+    clipboardData: {
+      getData() {
+        return 'Pasted text';
+      }
+    }
+  };
+  event.preventDefault = function() {
+      //do nothing
+  };
+
+  this.render(hbs`{{content-editable value=value maxlength='2000' class='jsTest-contentEditable'}}`);
+  const $element = this.$('.ember-content-editable');
+  await this.$('.jsTest-contentEditable').focus();
+
+  await $element.trigger($.Event('paste', event)); // paste fake event
+  assert.equal(this.get('value'), 'Pasted text', 'Pasted value is correct');
+
+});

--- a/tests/integration/components/content-editable-test.js
+++ b/tests/integration/components/content-editable-test.js
@@ -308,7 +308,7 @@ test('allowNewlines=false works', function(assert) {
   $element.trigger($.Event("keydown", { keyCode: 65 })); // Not enter
 });
 
-test('Pasting works', async function(assert) {
+test('Pasting works', function(assert) {
   assert.expect(1);
   this.set('value', "");
 
@@ -328,9 +328,9 @@ test('Pasting works', async function(assert) {
 
   this.render(hbs`{{content-editable value=value maxlength='2000' class='jsTest-contentEditable'}}`);
   const $element = this.$('.ember-content-editable');
-  await this.$('.jsTest-contentEditable').focus();
-
-  await $element.trigger($.Event('paste', event)); // paste fake event
+  this.$('.jsTest-contentEditable').focus();
+  $element.trigger($.Event('paste', event)); // paste fake event
   assert.equal(this.get('value'), 'Pasted text', 'Pasted value is correct');
+
 
 });

--- a/tests/integration/components/content-editable-test.js
+++ b/tests/integration/components/content-editable-test.js
@@ -7,6 +7,20 @@ function getPlaceholderContent(element) {
   return placeholderContent.replace(/"/g, ""); // presence of quotes varies in phantomjs vs chrome
 }
 
+//Make mock event
+const pasteEvent = document.createEvent("CustomEvent");
+pasteEvent.initCustomEvent('paste', true, true, null);
+pasteEvent.originalEvent = {
+  clipboardData: {
+    getData() {
+      return 'Pasted text';
+    }
+  }
+};
+pasteEvent.preventDefault = function() {
+    //do nothing
+};
+
 moduleForComponent('content-editable', 'Integration | Component | content editable', {
   integration: true
 });
@@ -308,29 +322,27 @@ test('allowNewlines=false works', function(assert) {
   $element.trigger($.Event("keydown", { keyCode: 65 })); // Not enter
 });
 
-test('Pasting works', function(assert) {
+test('Pasting works for text', function(assert) {
   assert.expect(1);
   this.set('value', "");
 
-  //Make mock event
-  let event = document.createEvent("CustomEvent");
-  event.initCustomEvent('paste', true, true, null);
-  event.originalEvent = {
-    clipboardData: {
-      getData() {
-        return 'Pasted text';
-      }
-    }
-  };
-  event.preventDefault = function() {
-      //do nothing
-  };
 
   this.render(hbs`{{content-editable value=value maxlength='2000' class='jsTest-contentEditable'}}`);
   const $element = this.$('.ember-content-editable');
   this.$('.jsTest-contentEditable').focus();
-  $element.trigger($.Event('paste', event)); // paste fake event
+  $element.trigger($.Event('paste', pasteEvent)); // paste fake event
   assert.equal(this.get('value'), 'Pasted text', 'Pasted value is correct');
 
+});
+
+test('Pasting works for html with no maxlength', function(assert) {
+  assert.expect(1);
+  this.set('value', "");
+
+  this.render(hbs`{{content-editable value=value type='html' class='jsTest-contentEditable '}}`);
+  const $element = this.$('.ember-content-editable');
+  this.$('.jsTest-contentEditable').focus();
+  $element.trigger($.Event('paste', pasteEvent)); // paste fake event
+  assert.equal(this.get('value'), 'Pasted text', 'Pasted value is correct');
 
 });


### PR DESCRIPTION
There wasn't an open issue for this.  But when you pasted text into the field, the paste would happen at the beginning not, where the cursor is.  It now pastes where the cursor is and retains cursor position.  Added a basic test for pasting as well and updated the acceptance test as I added more test fields to the dummy app.  

Also updated the babel options so we can use async await in the tests.