### PR TITLE
Avoid attaching paste event listener to every contenteditable item in the document

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -20,33 +20,35 @@ export default Component.extend({
   autofocus: false,
   clearPlaceholderOnFocus: false,
 
+  init() {
+    this._super();
+    this._pasteHandler = run.bind(this, this.pasteHandler);
+  },
+
   didInsertElement() {
     this._super(...arguments)
 
-    // register an observer on mutations of this component's dom
-    const observer = this.set('_mutationObserver', new MutationObserver(this.domChanged.bind(this)));
-    observer.observe(this.element, {attributes: false, childList: true, characterData: true, subtree: true});
-
+    this._mutationObserver = new MutationObserver(run.bind(this, this.domChanged));
+    this._mutationObserver.observe(this.element, {attributes: false, childList: true, characterData: true, subtree: true});
     this.updateDom();
 
     if (this.get('autofocus')) {
       this.element.focus();
     }
-    window.addEventListener('paste', this.set('_paste_function', this.pasteHandler.bind(this)), false);
+
+    this.element.addEventListener('paste', this._pasteHandler);
   },
 
-  willDestroyElement: function() {
-    window.removeEventListener('paste', this.get('_paste_function'), false);
-    this.get('_mutationObserver').disconnect();
+  willDestroyElement() {
+    this.element.removeEventListener('paste', this._pasteHandler);
+    this._mutationObserver.disconnect();
   },
 
   domChanged() {
-    run(()=> {
-      const text = this.element.innerText;
-      this.setProperties({
-        value: text,
-        _internalValue: text
-      });
+    const text = this.element.innerText;
+    this.setProperties({
+      value: text,
+      _internalValue: text
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.9.0",
-    "install": "^0.10.4"
+    "ember-cli-babel": "^6.9.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3343,10 +3343,6 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-install@^0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/install/-/install-0.10.4.tgz#9cb09115768b93a582d1450a6ba3f275975b49aa"
-
 invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"


### PR DESCRIPTION
Right now this event handler triggers on any contenteditable element within the document.  That's unlikely its intention, so I revised it to scope the paste event listener to the component's element and modified it with run.bind to ensure it runs the callback within the runloop.

Thanks for your addon <3