### PR TITLE
add ie11 paste support

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -125,7 +125,12 @@ export default Component.extend({
   pasteHandler(event) {
     event.preventDefault();
     // replace any html formatted text with its plain text equivalent
-    const text = event.clipboardData.getData("text/plain");
+    let text = '';
+    if (event.clipboardData) {
+      text = event.clipboardData.getData('text/plain');
+    } else if (window.clipboardData) {
+      text = window.clipboardData.getData('Text');
+    }
     // check max length
     if (this.get('maxlength')) {
       // a selection will be replaced. substract the length of the selection from the total length
@@ -136,7 +141,20 @@ export default Component.extend({
         return false;
       }
     }
-    document.execCommand("insertHTML", false, text);
+    if (document.queryCommandSupported('insertText')) {
+      document.execCommand('insertText', false, text);
+    } else {
+      let range = document.getSelection().getRangeAt(0);
+      range.deleteContents();
+      let textNode = document.createTextNode(text);
+      range.insertNode(textNode);
+      range.selectNodeContents(textNode);
+      range.collapse(false);
+
+      let selection = document.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
     this.get('paste')(text);
   },
 


### PR DESCRIPTION
ie11 does not support the clipboardData on the paste event, but has a seprate window wide clipboard data that it uses.

Also, ie11 does not support the  `insertText ` option of `document.execCommand` so instead we fall back on a selection, textnode, range hack to insert that text into the element.