### PR TITLE
Update dom before initializing MutationObserver

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -34,9 +34,9 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments)
 
+    this.updateDom();
     this._mutationObserver = new MutationObserver(run.bind(this, this.domChanged));
     this._mutationObserver.observe(this.element, {attributes: false, childList: true, characterData: true, subtree: true});
-    this.updateDom();
 
     if (this.get('autofocus')) {
       this.element.focus();


### PR DESCRIPTION
`updateDom` should be done before initializing `MutationObserver` because `domChanged` function can be immediatly triggered. This seems unneeded and can lead to bug.

In my case I use `content-editable` inside a modal and the `value` passed is reset to an empty string during init while content-editable innerText has the good value.
