### PR TITLE
Add a webkit specific css property to fix #83

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -9,6 +9,7 @@
 
 [contenteditable] {
   cursor: text;
+  -webkit-user-modify: read-write-plaintext-only;
 }
 
 .ember-content-editable:empty {


### PR DESCRIPTION
The **-webkit-user-modify** property was missing from the CSS.

With this property set on all [contenteditable] elements, Safari and Chrome deal with line breaks correctly. Additionally, it is just the right thing to do.

I used `read-write-plaintext-only` because this ember addon does not preserve rich text formatting from pasted text.

[See Related Safari Documenation](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266--webkit-user-modify)